### PR TITLE
fix: always cancel CursorHoldI event after move in normal mode

### DIFF
--- a/plugin/fix_cursorhold_nvim.vim
+++ b/plugin/fix_cursorhold_nvim.vim
@@ -29,8 +29,8 @@ function CursorHoldI_Cb(timer_id) abort
 endfunction
 
 function CursorHoldTimer() abort
+  call timer_stop(g:fix_cursorhold_nvim_timer)
   if mode() == 'n'
-    call timer_stop(g:fix_cursorhold_nvim_timer)
     let g:fix_cursorhold_nvim_timer = timer_start(g:cursorhold_updatetime, 'CursorHold_Cb')
   endif
 endfunction


### PR DESCRIPTION
`au User CocJumpPlaceholder call CocActionAsync('showSignatureHelp')` doesn't work as expected fired by `CompleteDone` event.
Signature window will be closed in `c` and `lua` under my test. We should always cancel `CursorHoldI` to avoid this issue.