### PR TITLE
fix: do not trigger CursorHold when exiting

### DIFF
--- a/plugin/fix_cursorhold_nvim.vim
+++ b/plugin/fix_cursorhold_nvim.vim
@@ -17,12 +17,18 @@ augroup fix_cursorhold_nvim
 augroup end
 
 function CursorHold_Cb(timer_id) abort
+  if v:exiting isnot v:null
+    return
+  endif
   set eventignore-=CursorHold
   doautocmd <nomodeline> CursorHold
   set eventignore+=CursorHold
 endfunction
 
 function CursorHoldI_Cb(timer_id) abort
+  if v:exiting isnot v:null
+    return
+  endif
   set eventignore-=CursorHoldI
   doautocmd <nomodeline> CursorHoldI
   set eventignore+=CursorHoldI


### PR DESCRIPTION
Steps that cause the problem:
1. Open a file with more than one line with Nvim and go to non-first line
2. `:autocmd CursorHold * echomsg localtime()`
3. `:call nvim_input('ggZ')`
4. Wait for several seconds and press `Q`

Without this PR time is printed to stderr. With this PR it is not.