### PR TITLE
Fix an invalid URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **❗ This plugin is not needed after https://github.com/neovim/neovim/pull/20198❗**
+# **❗ This plugin is not needed after https://github.com/neovim/neovim/pull/20198 ❗**
 
 Fix CursorHold Performance
 =================================


### PR DESCRIPTION
A "❗" just after the URL without any whitespaces is recognized as a part of the URL, so we can't open the URL as a valid URL when click it on the doc rendered.

Thank you.